### PR TITLE
Dsp3/zephyr 3.2

### DIFF
--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -1585,6 +1585,23 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* I2S_SD */
+			/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+			};
+
+			/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF5)>;
+			};
+
+			/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+			};
+
+			/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF5)>;
+			};
+
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/stm32cube/stm32h7xx/drivers/include/stm32h7xx_ll_spi.h
+++ b/stm32cube/stm32h7xx/drivers/include/stm32h7xx_ll_spi.h
@@ -3029,6 +3029,13 @@ __STATIC_INLINE uint32_t LL_I2S_GetStandard(SPI_TypeDef *SPIx)
 __STATIC_INLINE void LL_I2S_SetTransferMode(SPI_TypeDef *SPIx, uint32_t Standard)
 {
   MODIFY_REG(SPIx->I2SCFGR, SPI_I2SCFGR_I2SCFG, Standard);
+
+  if (Standard == LL_I2S_MODE_SLAVE_TX || Standard == LL_I2S_MODE_MASTER_TX) {
+  	MODIFY_REG(SPIx->CR1, SPI_CR1_HDDIR, SPI_CR1_HDDIR);
+  }
+  if (Standard == LL_I2S_MODE_SLAVE_TX || Standard == LL_I2S_MODE_MASTER_TX) {
+  	MODIFY_REG(SPIx->CR1, SPI_CR1_HDDIR, 0);
+  }
 }
 
 /**


### PR DESCRIPTION
Add Pin configuration for I2S and SPI_CR1_HDDIR management in `LL_I2S_SetTransferMode.